### PR TITLE
Improve error handling

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -17,9 +17,11 @@ const AUTHORITY_KEY = new TextEncoder('utf-8').encode('authority')
 const RESET_KEY = new TextEncoder('utf-8').encode('reset')
 const LOGS_KEY = new TextEncoder('utf-8').encode('logs')
 const EVENTS_KEY = new TextEncoder('utf-8').encode('events')
+const EXIT_CODE_KEY = new TextEncoder('utf-8').encode('exit_code')
 const ROLLBACK_TRANSACTION_KEY = new TextEncoder('utf-8').encode('rollback_transaction')
 const COMMIT_TRANSACTION_KEY = new TextEncoder('utf-8').encode('commit_transaction')
 const CHAIN_ID_KEY = new TextEncoder('utf-8').encode('chain_id')
+const ERROR_MESSAGE_KEY = new TextEncoder('utf-8').encode('error_message')
 
 module.exports = {
   METADATA_SPACE,
@@ -37,7 +39,9 @@ module.exports = {
   RESET_KEY,
   LOGS_KEY,
   EVENTS_KEY,
+  EXIT_CODE_KEY,
   ROLLBACK_TRANSACTION_KEY,
   COMMIT_TRANSACTION_KEY,
   CHAIN_ID_KEY,
+  ERROR_MESSAGE_KEY
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,11 +17,9 @@ const AUTHORITY_KEY = new TextEncoder('utf-8').encode('authority')
 const RESET_KEY = new TextEncoder('utf-8').encode('reset')
 const LOGS_KEY = new TextEncoder('utf-8').encode('logs')
 const EVENTS_KEY = new TextEncoder('utf-8').encode('events')
-const EXIT_CODE_KEY = new TextEncoder('utf-8').encode('exit_code')
 const ROLLBACK_TRANSACTION_KEY = new TextEncoder('utf-8').encode('rollback_transaction')
 const COMMIT_TRANSACTION_KEY = new TextEncoder('utf-8').encode('commit_transaction')
 const CHAIN_ID_KEY = new TextEncoder('utf-8').encode('chain_id')
-const ERROR_MESSAGE_KEY = new TextEncoder('utf-8').encode('error_message')
 
 module.exports = {
   METADATA_SPACE,
@@ -39,9 +37,7 @@ module.exports = {
   RESET_KEY,
   LOGS_KEY,
   EVENTS_KEY,
-  EXIT_CODE_KEY,
   ROLLBACK_TRANSACTION_KEY,
   COMMIT_TRANSACTION_KEY,
   CHAIN_ID_KEY,
-  ERROR_MESSAGE_KEY
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,19 +1,5 @@
-class ExitSuccess extends Error {
-  constructor (message) {
-    super(message)
-    this.code = 0
-  }
-}
-
-class ExitFailure extends Error {
-  constructor (message, code = -1) {
-    super(message)
-    this.code = code
-  }
-}
-
-class ExitReversion extends Error {
-  constructor (message, code = 1) {
+class KoinosError extends Error {
+  constructor (message, code) {
     super(message)
     this.code = code
   }
@@ -24,8 +10,6 @@ class ExecutionError extends Error {
 }
 
 module.exports = {
-  ExitSuccess,
-  ExitFailure,
-  ExitReversion,
+  KoinosError,
   ExecutionError
 }

--- a/src/index.js
+++ b/src/index.js
@@ -522,18 +522,25 @@ class MockVM {
     } catch (error) {
       if (error instanceof KoinosError) {
 
-        if (error.code != koinos.protocol.error_code.success) {
-          const msgBytes = StringToUInt8Array(error.message)
-          msgBytes.copy(retBuf)
-          retBytes = msgBytes.byteLength
-
+        try
+        {
           // Still store this metadata for testing purposes
           const exitCodeObj = new koinos.chain.value_type()
           exitCodeObj.int32_value = error.code
 
           this.db.putObject(METADATA_SPACE, EXIT_CODE_KEY, koinos.chain.value_type.encode(exitCodeObj).finish())
-          this.db.putObject(METADATA_SPACE, ERROR_MESSAGE_KEY, StringToUInt8Array(error.message))
+
+          if (error.code != koinos.protocol.error_code.success) {
+            const msgBytes = StringToUInt8Array(error.message)
+            msgBytes.copy(retBuf)
+            retBytes = msgBytes.byteLength
+
+            this.db.putObject(METADATA_SPACE, ERROR_MESSAGE_KEY, StringToUInt8Array(error.message))
+          }
+        } catch (e) {
+          console.log(e.message)
         }
+
 
         if (error.code >= koinos.protocol.error_code.reverted) {
           // revert database changes

--- a/src/index.js
+++ b/src/index.js
@@ -522,25 +522,19 @@ class MockVM {
     } catch (error) {
       if (error instanceof KoinosError) {
 
-        try
-        {
-          // Still store this metadata for testing purposes
-          const exitCodeObj = new koinos.chain.value_type()
-          exitCodeObj.int32_value = error.code
+        // Still store this metadata for testing purposes
+        const exitCodeObj = new koinos.chain.value_type()
+        exitCodeObj.int32_value = error.code
 
-          this.db.putObject(METADATA_SPACE, EXIT_CODE_KEY, koinos.chain.value_type.encode(exitCodeObj).finish())
+        this.db.putObject(METADATA_SPACE, EXIT_CODE_KEY, koinos.chain.value_type.encode(exitCodeObj).finish())
 
-          if (error.code != koinos.protocol.error_code.success) {
-            const msgBytes = StringToUInt8Array(error.message)
-            retBuf.set(msgBytes)
-            retBytes = msgBytes.byteLength
+        if (error.code != koinos.protocol.error_code.success) {
+          const msgBytes = StringToUInt8Array(error.message)
+          retBuf.set(msgBytes)
+          retBytes = msgBytes.byteLength
 
-            this.db.putObject(METADATA_SPACE, ERROR_MESSAGE_KEY, StringToUInt8Array(error.message))
-          }
-        } catch (e) {
-          console.log(e.message)
+          this.db.putObject(METADATA_SPACE, ERROR_MESSAGE_KEY, StringToUInt8Array(error.message))
         }
-
 
         if (error.code >= koinos.protocol.error_code.reverted) {
           // revert database changes

--- a/src/index.js
+++ b/src/index.js
@@ -532,7 +532,7 @@ class MockVM {
 
           if (error.code != koinos.protocol.error_code.success) {
             const msgBytes = StringToUInt8Array(error.message)
-            msgBytes.copy(retBuf)
+            retBuf.set(msgBytes)
             retBytes = msgBytes.byteLength
 
             this.db.putObject(METADATA_SPACE, ERROR_MESSAGE_KEY, StringToUInt8Array(error.message))

--- a/src/index.js
+++ b/src/index.js
@@ -65,12 +65,13 @@ class MockVM {
   }
 
   invokeSystemCall (sid, ret_ptr, ret_len, arg_ptr, arg_len, ret_bytes) {
+    const retBytesBuffer = new Uint32Array(this.memory.buffer, ret_bytes, 1 )
+    let retBytes = 0
+    let retVal = 0
+
     try {
       const argsBuf = new Uint8Array(this.memory.buffer, arg_ptr, arg_len)
       const retBuf = new Uint8Array(this.memory.buffer, ret_ptr, ret_len)
-      const retBytesBuffer = new Uint32Array(this.memory.buffer, ret_bytes, 1 )
-      let retBytes = 0
-      let retVal = 0
 
       switch (sid) {
         //////////////////////////////////////////////////
@@ -584,7 +585,7 @@ class MockVM {
       retVal = error.code;
     }
 
-    retBytes[0] = retBytes
+    retBytesBuffer[0] = retBytes
 
     return retVal
   }

--- a/src/index.js
+++ b/src/index.js
@@ -66,12 +66,12 @@ class MockVM {
 
   invokeSystemCall (sid, ret_ptr, ret_len, arg_ptr, arg_len, ret_bytes) {
     const retBytesBuffer = new Uint32Array(this.memory.buffer, ret_bytes, 1 )
+    const retBuf = new Uint8Array(this.memory.buffer, ret_ptr, ret_len)
     let retBytes = 0
     let retVal = 0
 
     try {
       const argsBuf = new Uint8Array(this.memory.buffer, arg_ptr, arg_len)
-      const retBuf = new Uint8Array(this.memory.buffer, ret_ptr, ret_len)
 
       switch (sid) {
         //////////////////////////////////////////////////

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,9 @@ const {
   EVENTS_KEY,
   ROLLBACK_TRANSACTION_KEY,
   COMMIT_TRANSACTION_KEY,
-  CHAIN_ID_KEY
+  CHAIN_ID_KEY,
+  EXIT_CODE_KEY,
+  ERROR_MESSAGE_KEY
 } = require('./constants')
 
 const { koinos } = require('koinos-proto-js')
@@ -523,6 +525,13 @@ class MockVM {
           const msgBytes = StringToUInt8Array(error.message)
           msgBytes.copy(retBuf)
           retBytes = msgBytes.byteLength
+
+          // Still store this metadata for testing purposes
+          const exitCodeObj = new koinos.chain.value_type()
+          exitCodeObj.int32_value = error.code
+
+          this.db.putObject(METADATA_SPACE, EXIT_CODE_KEY, koinos.chain.value_type.encode(exitCodeObj).finish())
+          this.db.putObject(METADATA_SPACE, ERROR_MESSAGE_KEY, StringToUInt8Array(error.message))
         }
 
         if (error.code >= koinos.protocol.error_code.reverted) {
@@ -538,7 +547,9 @@ class MockVM {
             TRANSACTION_KEY,
             BLOCK_KEY,
             AUTHORITY_KEY,
-            CALL_CONTRACT_RESULTS_KEY
+            CALL_CONTRACT_RESULTS_KEY,
+            EXIT_CODE_KEY,
+            ERROR_MESSAGE_KEY
           ]
 
           const bytes = keys.map((key) => {


### PR DESCRIPTION
## Brief description

Mock-VM changes required for koinos/koinos-chain#672

In addition to saving exit code and error messages to testing, write the error message to return bytes to match desired system specification.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
yarn run v1.22.18
$ asp --verbose -f=mockVM.spec.t
       ___   _____                       __    
      /   | / ___/      ____  ___  _____/ /_   
     / /| | \__ \______/ __ \/ _ \/ ___/ __/   
    / ___ |___/ /_____/ /_/ /  __/ /__/ /_     
   /_/  |_/____/     / .___/\___/\___/\__/     
                    /_/                        

⚡AS-pect⚡ Test suite runner [6.2.4]

[Log] Loading asc compiler
Assemblyscript Folder:assemblyscript
[Log] Compiler loaded in 512.502ms.
[Log] Using configuration /Users/mdv/git/koinos-sdk-as/as-pect.config.js
[Log] Using VerboseReporter
[Log] Including files: /Users/mdv/git/koinos-sdk-as/__tests__/**/*.spec.ts
[Log] Running tests that match: (:?)
[Log] Running groups that match: (:?)
[Log] Effective command line args:
  [TestFile.ts] node_modules/@as-pect/assembly/assembly/index.ts --runtime incremental --debug --binaryFile output.wasm --explicitStart --use ASC_RTRACE=1 --exportTable --importMemory --transform /Users/mdv/git/koinos-sdk-as/node_modules/@as-covers/transform/lib/index.js,/Users/mdv/git/koinos-sdk-as/node_modules/@as-pect/core/lib/transform/index.js --lib node_modules/@as-covers/assembly/index.ts

[Describe]: MockVM

 [Success]: ✔ should get the chain id RTrace: +34
 [Success]: ✔ should set the contract arguments RTrace: +57
 [Success]: ✔ should set the contract id RTrace: +31
 [Success]: ✔ should set the head info RTrace: +40
 [Success]: ✔ should set the last irreversible block RTrace: +32
 [Success]: ✔ should set the caller RTrace: +42
 [Success]: ✔ should set the transaction RTrace: +43
 [Success]: ✔ should set the block RTrace: +39
 [Success]: ✔ should set the authorities RTrace: +108
 [Success]: ✔ should set the call contract results RTrace: +82
 [Success]: ✔ should reset the MockVM database RTrace: +79
 [Success]: ✔ should handle transactions RTrace: +215
[Log] log 1
[Log] log 2
[Log] log 3
 [Success]: ✔ should handle logs RTrace: +168
 [Success]: ✔ should handle error messages RTrace: +44

    [File]: /Users/mdv/git/koinos-sdk-as/__tests__/mockVM.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 14 pass,  0 fail, 14 total
    [Time]: 127.347ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [Result]: ✔ PASS
   [Files]: 1 total
  [Groups]: 2 count, 2 pass
   [Tests]: 14 pass, 0 fail, 14 total
    [Time]: 9864.039ms
┌──────────────────────────────┬───────┬───────┬───────┬──────┬──────────────────────────────────────────────┐
│ File                         │ Total │ Block │ Func  │ Expr │ Uncovered                                    │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/systemCalls.ts      │ 28.8% │ 27.4% │ 30.6% │ 30%  │ 14:7, 43:58, 43:3, 54:76, 54:3, 65:93...     │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/base64.ts      │ 0%    │ 0%    │ 0%    │ 0%   │ 27:49, 32:20, 36:40, 38:42, 45:31, 45:42...  │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/base58.ts      │ 35%   │ 38.5% │ 66.7% │ 0%   │ 23:54, 36:30, 36:51, 46:28, 53:24, 53:39...  │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/stringBytes.ts │ 88.9% │ 80%   │ 100%  │ N/A  │ 18:24                                        │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/crypto.ts      │ 0%    │ 0%    │ 0%    │ N/A  │ 19:34, 19:5, 25:15, 25:5, 30:25, 30:5...     │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/arrays.ts      │ 19%   │ 15.4% │ 33.3% │ 20%  │ 12:26, 12:42, 16:26, 16:42, 20:42, 24:42...  │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/safeMath.ts    │ 0%    │ 0%    │ 0%    │ 0%   │ 10:40, 10:5, 32:57, 49:12, 33:25, 37:26...   │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/mockVM.ts      │ 85%   │ 82.6% │ 88.2% │ N/A  │ 267:58, 267:3, 384:63, 389:22, 392:74, 384:3 │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/token.ts       │ 0%    │ 0%    │ 0%    │ N/A  │ 25:39, 25:3, 38:18, 38:3, 57:20, 57:3...     │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ assembly/util/space.ts       │ 0%    │ 0%    │ 0%    │ 0%   │ 36:29, 31:5, 54:29, 57:23, 57:30, 54:5...    │
├──────────────────────────────┼───────┼───────┼───────┼──────┼──────────────────────────────────────────────┤
│ total                        │ 19.8% │ 20.2% │ 28.7% │ 4.8% │                                              │
└──────────────────────────────┴───────┴───────┴───────┴──────┴──────────────────────────────────────────────┘

✨  Done in 10.34s.
```
